### PR TITLE
add gcov and lcov for code coverage metrics for the sdk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,12 @@ set(BUILD_32BIT, 0)
 #####################################
 # Code Coverage for sdk
 #####################################
-# To run report on code coverage, add option flag -DBUILD_COVERAGE=1 to cmake command
-set(BUILD_COVERAGE, 0)
+# To run report on code coverage, add option flag -DENABLE_COVERAGE=1 to cmake command
+set(ENABLE_COVERAGE, 0)
+
+if (ENABLE_COVERAGE)
+set(BUILD_TESTS 1 CACHE STRING "Build the Test Suite")
+endif()
 
 if(BUILD_TESTS)
 add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,12 @@ set(BUILD_TESTS, 0)
 # To build 32 bit targets on a 64 bit architecture, add option flag -DBUILD_32BIT=1 to cmake command
 set(BUILD_32BIT, 0)
 
+#####################################
+# Code Coverage for sdk
+#####################################
+# To run report on code coverage, add option flag -DBUILD_COVERAGE=1 to cmake command
+set(BUILD_COVERAGE, 0)
+
 if(BUILD_TESTS)
 add_subdirectory(tests)
 endif()

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ You can run tests from the `build` folder by using commands below
 $ make ./run-tests
 ```
 
-You can run tests from the `build` folder by using commands below
+You can run a report on code coverage from the `build` folder by using commands below
 ```sh
 $ make ./run-code-coverage
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ $ sudo apt-get install build-essential
 $ sudo apt-get install git
 $ sudo apt-get install lcov
 ```
+Note: `lcov` version 1.13 or higher is needed.
+
 On 32 bit machines, you might also need multilib
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ $ cmake .. -DBUILD_TESTS=1
 $ make
 ```
 
-If you want to view the code coverage done by the tests, run
+If you want to build tests and enable code coverage, run
 
 ```sh
 $ cmake .. -DENABLE_COVERAGE=1
@@ -123,7 +123,7 @@ $ make ./run-tests
 
 You can run a report on code coverage from the `build` folder by using commands below
 ```sh
-$ sudo make ./run-code-coverage
+$ sudo make run-code-coverage
 ```
 
 You can view the code coverage report from the `build` folder by opening the

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Also, ensure your system has all the tools (g++, make, libc, git etc) to build c
 ```sh
 $ sudo apt-get install build-essential
 $ sudo apt-get install git
+$ sudo apt-get install lcov
 ```
 On 32 bit machines, you might also need multilib
 
@@ -90,11 +91,13 @@ Only sdk and sample targets are built by default. To build tests, run
 $ cmake .. -DBUILD_TESTS=1
 $ make
 ```
-If you want to view the code coverage done by the tests, set the flag -DBUILD_COVERAGE in addition to the -DBUILD_TESTS flag
+
+If you want to view the code coverage done by the tests, run
 
 ```sh
-$ cmake .. -DBUILD_TESTS=1 -DBUILD_COVERAGE=1
+$ cmake .. -DENABLE_COVERAGE=1
 ```
+Code coverage has a dependency on `gcov`, `lcov` & `genhtml`.
 
 If you want to build a 32 bit library on a 64 bit machine, set the flag DBUILD_32BIT
 
@@ -109,11 +112,17 @@ You can also build individual targets using below commands
 $ make appdynamicsiotsdk
 $ make sample
 $ make tests
+$ sudo make run-code-coverage
 ```
 
 You can run tests from the `build` folder by using commands below
 ```sh
 $ make ./run-tests
+```
+
+You can run tests from the `build` folder by using commands below
+```sh
+$ make ./run-code-coverage
 ```
 
 You can view the code coverage report from the `build` folder by opening the

--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ Only sdk and sample targets are built by default. To build tests, run
 $ cmake .. -DBUILD_TESTS=1
 $ make
 ```
+If you want to view the code coverage done by the tests, set the flag -DBUILD_COVERAGE in addition to the -DBUILD_TESTS flag
+
+```sh
+$ cmake .. -DBUILD_TESTS=1 -DBUILD_COVERAGE=1
+```
 
 If you want to build a 32 bit library on a 64 bit machine, set the flag DBUILD_32BIT
 
@@ -105,6 +110,14 @@ $ make appdynamicsiotsdk
 $ make sample
 $ make tests
 ```
+
+You can run tests from the `build` folder by using commands below
+```sh
+$ make ./run-tests
+```
+
+You can view the code coverage report from the `build` folder by opening the
+`out/index.html` file
 
 ## How to Use
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ You can also build individual targets using below commands
 $ make appdynamicsiotsdk
 $ make sample
 $ make tests
-$ sudo make run-code-coverage
 ```
 
 You can run tests from the `build` folder by using commands below
@@ -124,7 +123,7 @@ $ make ./run-tests
 
 You can run a report on code coverage from the `build` folder by using commands below
 ```sh
-$ make ./run-code-coverage
+$ sudo make ./run-code-coverage
 ```
 
 You can view the code coverage report from the `build` folder by opening the

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -31,7 +31,7 @@ if(BUILD_32BIT)
 set_target_properties(appdynamicsiotsdk PROPERTIES COMPILE_FLAGS "-m32" LINK_FLAGS "-m32")
 endif()
  
-if(BUILD_COVERAGE)
+if(ENABLE_COVERAGE)
 set_target_properties(appdynamicsiotsdk PROPERTIES COMPILE_FLAGS "--coverage")
 set_target_properties(appdynamicsiotsdk PROPERTIES LINK_FLAGS "--coverage")
 endif()

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -31,6 +31,11 @@ if(BUILD_32BIT)
 set_target_properties(appdynamicsiotsdk PROPERTIES COMPILE_FLAGS "-m32" LINK_FLAGS "-m32")
 endif()
  
+if(BUILD_COVERAGE)
+set_target_properties(appdynamicsiotsdk PROPERTIES COMPILE_FLAGS "--coverage")
+set_target_properties(appdynamicsiotsdk PROPERTIES LINK_FLAGS "--coverage")
+endif()
+
 #Set the location for library installation. Use "sudo make install" to apply
 install(TARGETS appdynamicsiotsdk DESTINATION /usr/lib)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ add_custom_target(run-tests COMMAND ./tests)
 add_dependencies(run-tests tests appdynamicsiotsdk)
 
 if (BUILD_COVERAGE)
+
 file (GLOB_RECURSE ALL_GCNO_FILES *.gcno)
 file (GLOB_RECURSE ALL_GCDA_FILES *.gcda)
 file (GLOB_RECURSE ALL_GCOV_FILES *.gcov)
@@ -70,6 +71,9 @@ add_custom_command(
     COMMAND lcov --capture --directory . --output-file appd-iot-cpp-coverage-tmp.info
     COMMAND lcov -r appd-iot-cpp-coverage-tmp.info "/usr/include/*" "*/iot-cpp-sdk/sdk/include/*" "*.hpp" --directory . --output-file appd-iot-cpp-coverage.info
     COMMAND genhtml appd-iot-cpp-coverage.info --output-directory out
+    COMMAND echo ""
+    COMMAND echo "Code Coverage Report is available at ${CMAKE_BINARY_DIR}/out/index.html"
+    COMMAND echo ""
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     VERBATIM)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,7 +72,6 @@ if (ENABLE_COVERAGE)
     IF(NOT GENHTML_PATH)
         MESSAGE(FATAL_ERROR "genhtml not found! Aborting...")
     ENDIF() # NOT GENHTML_PATH
-endif()
 
 add_custom_target(run-code-coverage
     COMMAND lcov --capture --directory . --output-file appd-iot-cpp-coverage-tmp.info
@@ -98,3 +97,5 @@ foreach (gcnofile ${ALL_GCNO_FILES})
     COMMENT "Running gcov"
     VERBATIM)
 endforeach()
+
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,3 +50,43 @@ target_link_libraries(tests ${APPD_SDK_LINK_LIBS} ${CGREEN_LINK_LIBS})
 add_custom_target(run-tests COMMAND ./tests)
 
 add_dependencies(run-tests tests appdynamicsiotsdk)
+
+if (BUILD_COVERAGE)
+file (GLOB_RECURSE ALL_GCNO_FILES *.gcno)
+file (GLOB_RECURSE ALL_GCDA_FILES *.gcda)
+file (GLOB_RECURSE ALL_GCOV_FILES *.gcov)
+file (GLOB_RECURSE ALL_INFO_FILES *.info)
+
+foreach (gcnofile ${ALL_GCNO_FILES})
+    add_custom_command(
+    TARGET run-tests POST_BUILD
+    COMMAND gcov -s ${CMAKE_SOURCE_DIR}/sdk/src -o ${CMAKE_BINARY_DIR}/sdk/CMakeFiles/appdynamicsiotsdk.dir/src/ ${gcnofile}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    VERBATIM)
+endforeach()
+
+add_custom_command(
+    TARGET run-tests POST_BUILD
+    COMMAND lcov --capture --directory . --output-file appd-iot-cpp-coverage-tmp.info
+    COMMAND lcov -r appd-iot-cpp-coverage-tmp.info "/usr/include/*" "*/iot-cpp-sdk/sdk/include/*" "*.hpp" --directory . --output-file appd-iot-cpp-coverage.info
+    COMMAND genhtml appd-iot-cpp-coverage.info --output-directory out
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    VERBATIM)
+
+foreach (gcnofile ${ALL_GCNO_FILES})
+    file(REMOVE_RECURSE ${gcnofile})
+endforeach()
+
+foreach (gcdafile ${ALL_GCDA_FILES})
+    file(REMOVE_RECURSE ${gcdafile})
+endforeach()
+
+foreach (gcovfile ${ALL_GCOV_FILES})
+    file(REMOVE_RECURSE ${gcovfile})
+endforeach()
+
+foreach (infofile ${ALL_INFO_FILES})
+    file(REMOVE_RECURSE ${infofile})
+endforeach()
+
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,46 +51,50 @@ add_custom_target(run-tests COMMAND ./tests)
 
 add_dependencies(run-tests tests appdynamicsiotsdk)
 
-if (BUILD_COVERAGE)
+##########################################
+# Target
+# run-code-coverage : create a code coverage report
+##########################################
 
-file (GLOB_RECURSE ALL_GCNO_FILES *.gcno)
-file (GLOB_RECURSE ALL_GCDA_FILES *.gcda)
-file (GLOB_RECURSE ALL_GCOV_FILES *.gcov)
-file (GLOB_RECURSE ALL_INFO_FILES *.info)
+if (ENABLE_COVERAGE)
+    FIND_PROGRAM(GCOV_PATH gcov)
+    FIND_PROGRAM(LCOV_PATH lcov)
+    FIND_PROGRAM(GENHTML_PATH genhtml)
 
-foreach (gcnofile ${ALL_GCNO_FILES})
-    add_custom_command(
-    TARGET run-tests POST_BUILD
-    COMMAND gcov -s ${CMAKE_SOURCE_DIR}/sdk/src -o ${CMAKE_BINARY_DIR}/sdk/CMakeFiles/appdynamicsiotsdk.dir/src/ ${gcnofile}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    VERBATIM)
-endforeach()
+    IF(NOT GCOV_PATH)
+        MESSAGE(FATAL_ERROR "gcov not found! Aborting...")
+    ENDIF() # NOT GCOV_PATH
 
-add_custom_command(
-    TARGET run-tests POST_BUILD
+    IF(NOT LCOV_PATH)
+        MESSAGE(FATAL_ERROR "lcov not found! Aborting...")
+    ENDIF() # NOT LCOV_PATH
+
+    IF(NOT GENHTML_PATH)
+        MESSAGE(FATAL_ERROR "genhtml not found! Aborting...")
+    ENDIF() # NOT GENHTML_PATH
+endif()
+
+add_custom_target(run-code-coverage
     COMMAND lcov --capture --directory . --output-file appd-iot-cpp-coverage-tmp.info
     COMMAND lcov -r appd-iot-cpp-coverage-tmp.info "/usr/include/*" "*/iot-cpp-sdk/sdk/include/*" "*.hpp" --directory . --output-file appd-iot-cpp-coverage.info
     COMMAND genhtml appd-iot-cpp-coverage.info --output-directory out
     COMMAND echo ""
     COMMAND echo "Code Coverage Report is available at ${CMAKE_BINARY_DIR}/out/index.html"
     COMMAND echo ""
+    COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_BINARY_DIR}/appd-iot-cpp-coverage-tmp.info
+    COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_BINARY_DIR}/appd-iot-cpp-coverage.info
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "generating HTML report from lcov files"
     VERBATIM)
 
+add_dependencies(run-code-coverage run-tests tests appdynamicsiotsdk)
+
+file (GLOB_RECURSE ALL_GCNO_FILES *.gcno)
 foreach (gcnofile ${ALL_GCNO_FILES})
-    file(REMOVE_RECURSE ${gcnofile})
+    add_custom_command(TARGET run-code-coverage PRE_BUILD
+    COMMAND echo " .... running gcov ..."
+    COMMAND gcov -s ${CMAKE_SOURCE_DIR}/sdk/src -o ${CMAKE_BINARY_DIR}/sdk/CMakeFiles/appdynamicsiotsdk.dir/src/ ${gcnofile}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Running gcov"
+    VERBATIM)
 endforeach()
-
-foreach (gcdafile ${ALL_GCDA_FILES})
-    file(REMOVE_RECURSE ${gcdafile})
-endforeach()
-
-foreach (gcovfile ${ALL_GCOV_FILES})
-    file(REMOVE_RECURSE ${gcovfile})
-endforeach()
-
-foreach (infofile ${ALL_INFO_FILES})
-    file(REMOVE_RECURSE ${infofile})
-endforeach()
-
-endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,7 +76,7 @@ endif()
 
 add_custom_target(run-code-coverage
     COMMAND lcov --capture --directory . --output-file appd-iot-cpp-coverage-tmp.info
-    COMMAND lcov -r appd-iot-cpp-coverage-tmp.info "/usr/include/*" "*/iot-cpp-sdk/sdk/include/*" "*.hpp" --directory . --output-file appd-iot-cpp-coverage.info
+    COMMAND lcov -r appd-iot-cpp-coverage-tmp.info "*/usr/include/*" "*/iot-cpp-sdk/sdk/include/*" "*.hpp" --directory . --output-file appd-iot-cpp-coverage.info
     COMMAND genhtml appd-iot-cpp-coverage.info --output-directory out
     COMMAND echo ""
     COMMAND echo "Code Coverage Report is available at ${CMAKE_BINARY_DIR}/out/index.html"


### PR DESCRIPTION
Fixes #13 
Use the modifications in README to see the output of gcov and lcov
The code coverage report can be read from build/out/index.html
This has been tested with the flags -DBUILD_TESTS & -DENABLE_COVERAGE
gcov, lcov and genhtml binaries were renamed : cmake aborted as expected